### PR TITLE
feat: add honeypot anti-spam channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,9 @@ ALLOWED_ORIGINS=https://tarkovtracker.org,https://www.tarkovtracker.org
 # Discord channel IDs for automated posts
 WELCOME_CHANNEL_ID=WELCOME_CHANNEL_ID
 
-# Optional: honeypot channel. Anyone who posts in this channel is banned on
+# honeypot channel. Anyone who posts in this channel is banned on
 # sight (falls back to kick if the ban fails). Leave unset to disable.
-# HONEYPOT_CHANNEL_ID=HONEYPOT_CHANNEL_ID
+HONEYPOT_CHANNEL_ID=HONEYPOT_CHANNEL_ID
 
 # Discord role IDs
 PANEL_ADMIN_ROLE_ID=PANEL_ADMIN_ROLE_ID

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ ALLOWED_ORIGINS=https://tarkovtracker.org,https://www.tarkovtracker.org
 # Discord channel IDs for automated posts
 WELCOME_CHANNEL_ID=WELCOME_CHANNEL_ID
 
+# Optional: honeypot channel. Anyone who posts in this channel is banned on
+# sight (falls back to kick if the ban fails). Leave unset to disable.
+# HONEYPOT_CHANNEL_ID=HONEYPOT_CHANNEL_ID
+
 # Discord role IDs
 PANEL_ADMIN_ROLE_ID=PANEL_ADMIN_ROLE_ID
 # Role IDs that grant admin-only commands (e.g. /wipe). Comma-separated.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Requires **Node.js 18+**.
 - Automated welcome messages and auto-roles for new members
 - Quick announcement helpers (`/message`, `/faq1`, `/utd`)
 - One-command channel archiving (`/archive`)
+- Honeypot anti-spam channel that auto-bans anyone who posts in it
 - Public web forms that open GitHub issues for bug and data reports
 
 ## Getting started
@@ -47,7 +48,7 @@ Copy `.env.example` to `.env` and fill in every value:
 
 - **Discord bot basics:** `DISCORD_TOKEN`, `ADMIN_ROLE_ID` (comma-separated Discord role IDs granting admin-only commands such as `/wipe`)
 - **GitHub issue routing:** `GITHUB_TOKEN`, `REPO_DEV`, `REPO_DATA_REPORT`
-- **Channel IDs for automated posts:** `WELCOME_CHANNEL_ID`
+- **Channel IDs for automated posts:** `WELCOME_CHANNEL_ID`; optional `HONEYPOT_CHANNEL_ID` (a hidden channel — anyone who posts in it is banned on sight, with a kick fallback; messages older than 16h are swept hourly)
 - **Role IDs:** `PANEL_ADMIN_ROLE_ID`, `AUTO_ROLE_ID_1`–`AUTO_ROLE_ID_4` (auto-roles for new members); optional `ALLOWED_COMMAND_ROLE_IDS` (comma-separated role IDs allowed to use member commands, falls back to a built-in default)
 - **Web server:** `PORT`, `ALLOWED_ORIGINS` (comma-separated origins, exact match)
 

--- a/bot.js
+++ b/bot.js
@@ -5,6 +5,7 @@ import { ensureEnvVars } from "./src/config/env.js";
 import { registerSlashCommands } from "./src/commands/registerSlashCommands.js";
 import { registerInteractionHandler } from "./src/handlers/interactionHandler.js";
 import { registerMemberHandlers } from "./src/handlers/memberHandlers.js";
+import { setupHoneypot } from "./src/handlers/honeypotHandler.js";
 
 ensureEnvVars();
 
@@ -23,5 +24,6 @@ client.once(Events.ClientReady, async () => {
 
 registerInteractionHandler(client);
 registerMemberHandlers(client);
+setupHoneypot(client);
 
 client.login(process.env.DISCORD_TOKEN);

--- a/src/handlers/honeypotHandler.js
+++ b/src/handlers/honeypotHandler.js
@@ -1,0 +1,125 @@
+import { Events } from "discord.js";
+
+// Honeypot channel: a hidden channel that real users should never post in.
+// Bots/spam accounts that find it and send a message are banned on sight.
+// Activates only when HONEYPOT_CHANNEL_ID is set; otherwise this is a no-op.
+
+const HONEYPOT_CHANNEL_ID = process.env.HONEYPOT_CHANNEL_ID;
+
+// Stable marker embedded in the bot's warning message so we can detect it
+// across restarts without persisting state.
+const HONEYPOT_MARKER = "<!-- trackerbot-honeypot-message -->";
+
+const HONEYPOT_WARNING = `${HONEYPOT_MARKER}\n**⚠️ Honeypot channel** — do not post here.`;
+
+const SIXTEEN_HOURS_MS = 16 * 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
+const BULK_DELETE_LIMIT_MS = 14 * 24 * 60 * 60 * 1000; // Discord bulk-delete window
+
+export function setupHoneypot(client) {
+  if (!HONEYPOT_CHANNEL_ID) return;
+
+  client.on(Events.ClientReady, async () => {
+    try {
+      const channel = client.channels.cache.get(HONEYPOT_CHANNEL_ID);
+      if (!channel?.isTextBased()) {
+        console.warn(`Honeypot channel not found or not text-based: ${HONEYPOT_CHANNEL_ID}`);
+        return;
+      }
+
+      await ensureHoneypotMessage(channel);
+      await cleanupOldMessages(channel);
+
+      // Recurring sweep for messages older than 16h.
+      setInterval(() => {
+        cleanupOldMessages(channel).catch(err =>
+          console.error("Honeypot cleanup failed:", err)
+        );
+      }, CLEANUP_INTERVAL_MS);
+    } catch (err) {
+      console.error("Failed to set up honeypot:", err);
+    }
+  });
+
+  client.on(Events.MessageCreate, async message => {
+    if (message.channelId !== HONEYPOT_CHANNEL_ID) return;
+    if (message.author.bot) return;
+
+    try {
+      await message.delete();
+    } catch (err) {
+      console.error("Failed to delete honeypot trigger message:", err);
+    }
+
+    await punishAuthor(message);
+  });
+}
+
+// Send the warning message only if no existing bot message carries the marker.
+async function ensureHoneypotMessage(channel) {
+  const recent = await channel.messages.fetch({ limit: 50 });
+  const exists = recent.some(
+    msg => msg.author.bot && msg.content?.includes(HONEYPOT_MARKER)
+  );
+  if (!exists) {
+    await channel.send(HONEYPOT_WARNING);
+  }
+}
+
+// Delete messages older than 16h, preserving the honeypot warning message.
+// Uses bulk delete for messages within Discord's 14-day window, individual
+// delete otherwise.
+async function cleanupOldMessages(channel) {
+  const now = Date.now();
+  const recent = await channel.messages.fetch({ limit: 100 });
+
+  const toDelete = recent.filter(
+    msg => now - msg.createdTimestamp > SIXTEEN_HOURS_MS &&
+      !(msg.author.bot && msg.content?.includes(HONEYPOT_MARKER))
+  );
+
+  if (toDelete.size === 0) return;
+
+  const bulkable = toDelete.filter(
+    msg => now - msg.createdTimestamp <= BULK_DELETE_LIMIT_MS
+  );
+  const individual = toDelete.filter(
+    msg => now - msg.createdTimestamp > BULK_DELETE_LIMIT_MS
+  );
+
+  if (bulkable.size > 0) {
+    try {
+      await channel.bulkDelete([...bulkable.values()]);
+    } catch (err) {
+      console.error("Honeypot bulk delete failed:", err);
+    }
+  }
+
+  for (const msg of individual.values()) {
+    try {
+      await msg.delete();
+    } catch (err) {
+      console.error("Honeypot individual delete failed:", err);
+    }
+  }
+}
+
+// Ban the offender; fall back to kick if the ban fails (permissions/hierarchy).
+async function punishAuthor(message) {
+  const { author, guild } = message;
+  const reason = "Posted in the honeypot channel";
+
+  try {
+    await guild.bans.create(author.id, { reason });
+    console.log(`Honeypot: banned ${author.tag} (${author.id})`);
+  } catch (err) {
+    console.error(`Honeypot: ban failed for ${author.tag} (${author.id}), trying kick:`, err);
+    try {
+      const member = await guild.members.fetch(author.id);
+      await member.kick(reason);
+      console.log(`Honeypot: kicked ${author.tag} (${author.id})`);
+    } catch (kickErr) {
+      console.error(`Honeypot: kick also failed for ${author.tag} (${author.id}):`, kickErr);
+    }
+  }
+}

--- a/src/handlers/honeypotHandler.js
+++ b/src/handlers/honeypotHandler.js
@@ -15,11 +15,17 @@ const HONEYPOT_WARNING = `${HONEYPOT_MARKER}\n**⚠️ Honeypot channel** — do
 const SIXTEEN_HOURS_MS = 16 * 60 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
 const BULK_DELETE_LIMIT_MS = 14 * 24 * 60 * 60 * 1000; // Discord bulk-delete window
+// Cap pagination so a runaway channel can't trigger unbounded API calls.
+// A honeypot should hold ~1 message in steady state; 1000 is a generous ceiling.
+const MAX_FETCH_PAGES = 10;
+const PAGE_SIZE = 100;
 
 export function setupHoneypot(client) {
   if (!HONEYPOT_CHANNEL_ID) return;
 
-  client.on(Events.ClientReady, async () => {
+  // Use `once`: discord.js re-emits ClientReady on reconnect, and `on` would
+  // register a fresh setInterval each time, leaking cleanup timers.
+  client.once(Events.ClientReady, async () => {
     try {
       const channel = client.channels.cache.get(HONEYPOT_CHANNEL_ID);
       if (!channel?.isTextBased()) {
@@ -56,51 +62,67 @@ export function setupHoneypot(client) {
 }
 
 // Send the warning message only if no existing bot message carries the marker.
+// Paginates so an existing marker beyond the first page isn't missed.
 async function ensureHoneypotMessage(channel) {
-  const recent = await channel.messages.fetch({ limit: 50 });
-  const exists = recent.some(
-    msg => msg.author.bot && msg.content?.includes(HONEYPOT_MARKER)
-  );
-  if (!exists) {
-    await channel.send(HONEYPOT_WARNING);
+  for await (const messages of fetchMessagePages(channel)) {
+    if (messages.some(msg => msg.author.bot && msg.content?.includes(HONEYPOT_MARKER))) {
+      return; // marker found — no duplicate needed
+    }
   }
+  await channel.send(HONEYPOT_WARNING);
 }
 
 // Delete messages older than 16h, preserving the honeypot warning message.
 // Uses bulk delete for messages within Discord's 14-day window, individual
-// delete otherwise.
+// delete otherwise. Paginates so older messages beyond the first page are swept.
 async function cleanupOldMessages(channel) {
   const now = Date.now();
-  const recent = await channel.messages.fetch({ limit: 100 });
+  for await (const messages of fetchMessagePages(channel)) {
+    const toDelete = messages.filter(
+      msg => now - msg.createdTimestamp > SIXTEEN_HOURS_MS &&
+        !(msg.author.bot && msg.content?.includes(HONEYPOT_MARKER))
+    );
 
-  const toDelete = recent.filter(
-    msg => now - msg.createdTimestamp > SIXTEEN_HOURS_MS &&
-      !(msg.author.bot && msg.content?.includes(HONEYPOT_MARKER))
-  );
+    if (toDelete.size === 0) continue;
 
-  if (toDelete.size === 0) return;
+    const bulkable = toDelete.filter(
+      msg => now - msg.createdTimestamp <= BULK_DELETE_LIMIT_MS
+    );
+    const individual = toDelete.filter(
+      msg => now - msg.createdTimestamp > BULK_DELETE_LIMIT_MS
+    );
 
-  const bulkable = toDelete.filter(
-    msg => now - msg.createdTimestamp <= BULK_DELETE_LIMIT_MS
-  );
-  const individual = toDelete.filter(
-    msg => now - msg.createdTimestamp > BULK_DELETE_LIMIT_MS
-  );
+    if (bulkable.size > 0) {
+      try {
+        await channel.bulkDelete([...bulkable.values()]);
+      } catch (err) {
+        console.error("Honeypot bulk delete failed:", err);
+      }
+    }
 
-  if (bulkable.size > 0) {
-    try {
-      await channel.bulkDelete([...bulkable.values()]);
-    } catch (err) {
-      console.error("Honeypot bulk delete failed:", err);
+    for (const msg of individual.values()) {
+      try {
+        await msg.delete();
+      } catch (err) {
+        console.error("Honeypot individual delete failed:", err);
+      }
     }
   }
+}
 
-  for (const msg of individual.values()) {
-    try {
-      await msg.delete();
-    } catch (err) {
-      console.error("Honeypot individual delete failed:", err);
-    }
+// Yields pages of channel messages newest-first, using a `before` cursor.
+// Bounded by MAX_FETCH_PAGES to prevent unbounded API calls on a runaway channel.
+async function* fetchMessagePages(channel) {
+  let before;
+  for (let i = 0; i < MAX_FETCH_PAGES; i++) {
+    const messages = await channel.messages.fetch({
+      limit: PAGE_SIZE,
+      ...(before ? { before } : {})
+    });
+    if (messages.size === 0) return;
+    yield messages;
+    before = messages.last().id; // oldest in this page → continue backwards
+    if (messages.size < PAGE_SIZE) return; // exhausted history
   }
 }
 

--- a/test/honeypot.test.js
+++ b/test/honeypot.test.js
@@ -25,18 +25,22 @@ test("setupHoneypot is a no-op when HONEYPOT_CHANNEL_ID is unset", async () => {
   assert.equal(registered, false, "no listeners should be registered when disabled");
 });
 
-test("setupHoneypot registers a MessageCreate listener when enabled", async () => {
+test("setupHoneypot registers listeners when enabled", async () => {
   process.env.HONEYPOT_CHANNEL_ID = "123";
   const { setupHoneypot } = await importHoneypot();
 
-  const events = {};
+  const onEvents = {};
+  const onceEvents = {};
   const fakeClient = {
-    on: (evt, fn) => { events[evt] = fn; },
-    once: () => {}
+    on: (evt, fn) => { onEvents[evt] = fn; },
+    once: (evt, fn) => { onceEvents[evt] = fn; }
   };
 
   setupHoneypot(fakeClient);
-  assert.ok(events.messageCreate, "MessageCreate listener should be registered when enabled");
+  assert.ok(onEvents.messageCreate, "MessageCreate listener should be registered via .on");
+  // ClientReady must be registered via .once (not .on) to avoid timer leaks on reconnect.
+  assert.ok(onceEvents.clientReady, "ClientReady handler should be registered via .once");
+  assert.equal(onEvents.clientReady, undefined, "ClientReady must not use .on");
 
   delete process.env.HONEYPOT_CHANNEL_ID;
 });

--- a/test/honeypot.test.js
+++ b/test/honeypot.test.js
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// honeypotHandler reads HONEYPOT_CHANNEL_ID at module load. We re-import with
+// cache busting per scenario so the env state is respected.
+
+async function importHoneypot() {
+  const url = new URL("../src/handlers/honeypotHandler.js", import.meta.url).href + "?t=" + Date.now();
+  return import(url);
+}
+
+test("setupHoneypot is a no-op when HONEYPOT_CHANNEL_ID is unset", async () => {
+  delete process.env.HONEYPOT_CHANNEL_ID;
+  const { setupHoneypot } = await importHoneypot();
+
+  // A fake client with spies; if setupHoneypot registers anything it would
+  // call .on(). With the env var unset it must return early.
+  let registered = false;
+  const fakeClient = {
+    on: () => { registered = true; },
+    once: () => { registered = true; }
+  };
+
+  setupHoneypot(fakeClient);
+  assert.equal(registered, false, "no listeners should be registered when disabled");
+});
+
+test("setupHoneypot registers a MessageCreate listener when enabled", async () => {
+  process.env.HONEYPOT_CHANNEL_ID = "123";
+  const { setupHoneypot } = await importHoneypot();
+
+  const events = {};
+  const fakeClient = {
+    on: (evt, fn) => { events[evt] = fn; },
+    once: () => {}
+  };
+
+  setupHoneypot(fakeClient);
+  assert.ok(events.messageCreate, "MessageCreate listener should be registered when enabled");
+
+  delete process.env.HONEYPOT_CHANNEL_ID;
+});


### PR DESCRIPTION
## **User description**
## Summary
- Adds an optional honeypot channel (`HONEYPOT_CHANNEL_ID`) that auto-bans anyone who posts in it, falling back to kick if the ban fails (permissions/hierarchy).
- On startup the bot posts an idempotent warning message — skipped if one already exists (detected via a stable marker, no persisted state needed).
- Sweeps messages older than 16h hourly (and once on startup), preserving the warning message. Uses Discord bulk-delete within the 14-day window and individual deletes beyond it.
- `HONEYPOT_CHANNEL_ID` is **optional** — when unset the feature is a no-op, so existing deployments and the test suite are unaffected.
- New module lives at `src/handlers/honeypotHandler.js`, following the existing `setupXxx(client)` handler pattern and wired into `bot.js`.

Closes #24.

## Design notes
- `setInterval` (hourly) over cron/sweepers: the bot process is already the scheduler, and discord.js sweepers only clear the local cache, not Discord messages.
- Ban over kick: honeypots catch bot/spam accounts — banning prevents rejoining. Kick is the fallback.
- Idempotency via an HTML-comment marker in the bot's warning message, detected by fetching recent messages on startup.

#### Test plan
- [x] `npm test` — 6/6 pass (4 existing env tests + 2 new honeypot tests: no-op when unset, registers listener when enabled)
- [x] `node --check` syntax sweep passes on all JS files
- [x] No changes to `requiredEnvVars` — feature is opt-in


___

## **CodeAnt-AI Description**
**Add an optional honeypot channel that bans spam accounts and keeps the channel clean**

### What Changed
- When the optional honeypot channel is enabled, anyone who posts in it is banned immediately, with a kick fallback if banning is not allowed
- The bot now posts one warning message in that channel and reuses it after restarts instead of creating duplicates
- Messages older than 16 hours are removed on startup and then swept every hour, while preserving the warning message
- Added tests to confirm the feature stays inactive when the channel is not configured and turns on when it is
- Updated the setup docs and example env file to explain how to enable the honeypot channel

### Impact
`✅ Fewer spam posts in hidden channels`
`✅ Faster removal of unwanted messages`
`✅ Clearer setup for optional anti-spam protection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
