### PR TITLE
fix: whitelist admins from honeypot and make warning more prominent

### DIFF
--- a/src/handlers/honeypotHandler.js
+++ b/src/handlers/honeypotHandler.js
@@ -52,17 +52,24 @@ export function setupHoneypot(client) {
     if (message.channelId !== HONEYPOT_CHANNEL_ID) return;
     if (message.author.bot) return;
 
-    // Admins are whitelisted so the honeypot can never ban/kick them, even if
-    // they post here intentionally. Uses the shared ADMIN_ROLE_ID config.
-    if (message.member && hasAdminRole(message.member.roles.cache)) return;
-
     try {
-      await message.delete();
-    } catch (err) {
-      console.error("Failed to delete honeypot trigger message:", err);
-    }
+      // Fetch the member when Discord did not hydrate it in the event so the
+      // admin exemption cannot be bypassed by a missing message.member value.
+      const member = message.member ?? await message.guild.members.fetch(message.author.id);
+      if (hasAdminRole(member.roles.cache)) return;
 
-    await punishAuthor(message);
+      try {
+        await message.delete();
+      } catch (err) {
+        console.error("Failed to delete honeypot trigger message:", err);
+      }
+
+      await punishAuthor(message);
+    } catch (err) {
+      // Fail safe: if member resolution or role inspection fails, do not risk
+      // punishing an administrator.
+      console.error("Failed to handle honeypot message:", err);
+    }
   });
 }
 

--- a/src/handlers/honeypotHandler.js
+++ b/src/handlers/honeypotHandler.js
@@ -1,4 +1,5 @@
 import { Events } from "discord.js";
+import { hasAdminRole } from "../config/constants.js";
 
 // Honeypot channel: a hidden channel that real users should never post in.
 // Bots/spam accounts that find it and send a message are banned on sight.
@@ -10,7 +11,7 @@ const HONEYPOT_CHANNEL_ID = process.env.HONEYPOT_CHANNEL_ID;
 // across restarts without persisting state.
 const HONEYPOT_MARKER = "<!-- trackerbot-honeypot-message -->";
 
-const HONEYPOT_WARNING = `${HONEYPOT_MARKER}\n**⚠️ Honeypot channel** — do not post here.`;
+const HONEYPOT_WARNING = `${HONEYPOT_MARKER}\n# ⛔️⚠️ DO NOT SEND MESSAGES HERE, YOU WILL BE BANNED INSTANTLY ⚠️⛔️`;
 
 const SIXTEEN_HOURS_MS = 16 * 60 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // hourly
@@ -50,6 +51,10 @@ export function setupHoneypot(client) {
   client.on(Events.MessageCreate, async message => {
     if (message.channelId !== HONEYPOT_CHANNEL_ID) return;
     if (message.author.bot) return;
+
+    // Admins are whitelisted so the honeypot can never ban/kick them, even if
+    // they post here intentionally. Uses the shared ADMIN_ROLE_ID config.
+    if (message.member && hasAdminRole(message.member.roles.cache)) return;
 
     try {
       await message.delete();

--- a/test/honeypot.test.js
+++ b/test/honeypot.test.js
@@ -9,6 +9,19 @@ async function importHoneypot() {
   return import(url);
 }
 
+function createFakeClient() {
+  const onEvents = {};
+  const onceEvents = {};
+  return {
+    onEvents,
+    onceEvents,
+    client: {
+      on: (evt, fn) => { onEvents[evt] = fn; },
+      once: (evt, fn) => { onceEvents[evt] = fn; }
+    }
+  };
+}
+
 test("setupHoneypot is a no-op when HONEYPOT_CHANNEL_ID is unset", async () => {
   delete process.env.HONEYPOT_CHANNEL_ID;
   const { setupHoneypot } = await importHoneypot();
@@ -29,18 +42,71 @@ test("setupHoneypot registers listeners when enabled", async () => {
   process.env.HONEYPOT_CHANNEL_ID = "123";
   const { setupHoneypot } = await importHoneypot();
 
-  const onEvents = {};
-  const onceEvents = {};
-  const fakeClient = {
-    on: (evt, fn) => { onEvents[evt] = fn; },
-    once: (evt, fn) => { onceEvents[evt] = fn; }
-  };
+  const { client, onEvents, onceEvents } = createFakeClient();
 
-  setupHoneypot(fakeClient);
+  setupHoneypot(client);
   assert.ok(onEvents.messageCreate, "MessageCreate listener should be registered via .on");
   // ClientReady must be registered via .once (not .on) to avoid timer leaks on reconnect.
   assert.ok(onceEvents.clientReady, "ClientReady handler should be registered via .once");
   assert.equal(onEvents.clientReady, undefined, "ClientReady must not use .on");
 
+  delete process.env.HONEYPOT_CHANNEL_ID;
+});
+
+test("honeypot resolves a missing member before enforcing the admin exemption", async () => {
+  process.env.HONEYPOT_CHANNEL_ID = "123";
+  const { adminRoles } = await import("../src/config/constants.js");
+  adminRoles.add("admin");
+  const { setupHoneypot } = await importHoneypot();
+  const { client, onEvents } = createFakeClient();
+  setupHoneypot(client);
+
+  let deleted = false;
+  let banned = false;
+  const adminMember = { roles: { cache: [{ id: "admin" }] } };
+  await onEvents.messageCreate({
+    channelId: "123",
+    author: { id: "user", bot: false },
+    member: null,
+    guild: {
+      members: { fetch: async () => adminMember },
+      bans: { create: async () => { banned = true; } }
+    },
+    delete: async () => { deleted = true; }
+  });
+
+  assert.equal(deleted, false, "admin message should not be deleted");
+  assert.equal(banned, false, "admin should not be banned");
+  adminRoles.delete("admin");
+  delete process.env.HONEYPOT_CHANNEL_ID;
+});
+
+test("honeypot fails safe when a missing member cannot be resolved", async () => {
+  process.env.HONEYPOT_CHANNEL_ID = "123";
+  const { setupHoneypot } = await importHoneypot();
+  const { client, onEvents } = createFakeClient();
+  setupHoneypot(client);
+
+  let deleted = false;
+  let banned = false;
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  try {
+    await onEvents.messageCreate({
+      channelId: "123",
+      author: { id: "user", bot: false },
+      member: null,
+      guild: {
+        members: { fetch: async () => { throw new Error("unavailable"); } },
+        bans: { create: async () => { banned = true; } }
+      },
+      delete: async () => { deleted = true; }
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  assert.equal(deleted, false, "message should remain when roles cannot be checked");
+  assert.equal(banned, false, "author should not be punished when roles cannot be checked");
   delete process.env.HONEYPOT_CHANNEL_ID;
 });


### PR DESCRIPTION
## **User description**
## Summary
- Whitelist members with an admin role so the honeypot can never ban/kick them, reusing the existing `ADMIN_ROLE_ID` config via the shared `hasAdminRole` helper (same one used by `/wipe` and `/nuke`).
- Replace the subtle warning message with a prominent Discord heading so users clearly understand they will be banned instantly if they post in the channel.

## Test plan
- [x] `node --check` syntax sweep passes for all JS files
- [x] `npm test` — all 9 tests pass
- [x] Honeypot tests confirm listeners register correctly and no-op when disabled
- [ ] Manual: verify an admin posting in the honeypot channel is not punished
- [ ] Manual: verify the new warning message renders as a heading in Discord


___

## **CodeAnt-AI Description**
**Keep admins safe in the honeypot channel and make the warning impossible to miss**

### What Changed
- Members with an admin role are no longer deleted, banned, or kicked if they post in the honeypot channel
- The honeypot warning now appears as a large, prominent heading that clearly says messages there will trigger an instant ban

### Impact
`✅ Fewer accidental admin bans`
`✅ Clearer honeypot warnings`
`✅ Less confusion when staff test the channel`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
