### PR TITLE
fix: ticket category on discord

### DIFF
--- a/src/interactions/buttonHandlers.js
+++ b/src/interactions/buttonHandlers.js
@@ -29,7 +29,7 @@ async function handleTicketCreation(interaction) {
   const member = interaction.member;
 
   const ticketCategory = guild.channels.cache.find(
-    c => c.type === ChannelType.GuildCategory && c.name.toLowerCase() === "ticket"
+    c => c.type === ChannelType.GuildCategory && c.name.toLowerCase() === "🆘 --- Support ---"
   );
 
   if (!ticketCategory) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes ticket creation to target the Discord category named "🆘 --- Support ---" instead of "ticket", so new tickets are filed under the correct category.

- Changes the category lookup from "ticket" to "🆘 --- Support ---".
- The code lowercases channel names but compares to a mixed-case literal; consider lowercasing the literal to "🆘 --- support ---" or removing the lowercase to avoid mismatches.
- If the category is missing, existing fallback behavior remains; ensure the server has a category named "🆘 --- Support ---".

<sup>Written for commit 077f4772d12df1aa7959366ed7165acbeb837afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tarkovtracker-org/TrackerBot/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

